### PR TITLE
Prove rover controllers cannot command a crash

### DIFF
--- a/src/rover-autonomous.adb
+++ b/src/rover-autonomous.adb
@@ -21,6 +21,9 @@ is
    procedure Next_Mast_Pos (This : in out Auto_State;
                             Min, Max : Mast_Angle;
                             Period : Time)
+   with
+     Pre  => Initialized,
+     Post => Initialized
    is
       Now : constant Time := Clock;
    begin
@@ -53,7 +56,11 @@ is
    -- Check_User_Input --
    ----------------------
 
-   procedure Check_User_Input (This : in out Auto_State) is
+   procedure Check_User_Input (This : in out Auto_State)
+   with
+     Pre  => Initialized,
+     Post => Initialized
+   is
       State : Buttons_State;
    begin
       State := Update;
@@ -64,7 +71,11 @@ is
    -- Go_Forward --
    ----------------
 
-   procedure Go_Forward (This : in out Auto_State) is
+   procedure Go_Forward (This : in out Auto_State) with
+     Pre  => Initialized and then
+             Rover.Cannot_Crash,
+     Post => Initialized
+   is
       Distance : Unsigned_32;
    begin
 
@@ -94,7 +105,12 @@ is
    -- Turn_Around --
    -----------------
 
-   procedure Turn_Around is
+   procedure Turn_Around
+   with
+     Pre  => Initialized,
+     Post => Initialized and then
+             Rover.Cannot_Crash
+   is
    begin
       --  Turn around, full speed
       --  TODO: Ramdom direction, keep turning if an obstacle is detected
@@ -109,7 +125,12 @@ is
    -- Find_New_Direction --
    ------------------------
 
-   procedure Find_New_Direction (This : in out Auto_State) is
+   procedure Find_New_Direction (This : in out Auto_State)
+     with
+      Pre  => Initialized,
+      Post => Initialized and then
+              Rover.Cannot_Crash
+   is
       Left_Dist : Unsigned_32 := 0;
       Right_Dist : Unsigned_32 := 0;
 
@@ -181,6 +202,8 @@ is
       while not State.User_Exit loop
          Go_Forward (State);
          Find_New_Direction (State);
+
+         pragma Loop_Invariant (Rover.Cannot_Crash);
       end loop;
 
       --  Stop everything before leaving the autonomous mode

--- a/src/rover-autonomous.ads
+++ b/src/rover-autonomous.ads
@@ -5,7 +5,10 @@ with SPARK_Mode
 is
 
    procedure Run
-     with Pre => Rover_HAL.Initialized;
+     with
+      Pre => Rover_HAL.Initialized,
+      Post => Rover_HAL.Initialized and then
+              Rover.Cannot_Crash;
    --  Run the autonomous routine until a button is pressed on the remote
 
 end Rover.Autonomous;

--- a/src/rover-remote_controlled.adb
+++ b/src/rover-remote_controlled.adb
@@ -52,7 +52,8 @@ is
       Buttons : Buttons_State;
       Dist : Unsigned_32;
 
-      Cmd, Last_Cmd : Remote_Command := None;
+      Cmd : Remote_Command := None;
+      Last_Cmd : Remote_Command;
 
       Now : Time;
       Last_Interaction_Time : Time;
@@ -66,15 +67,16 @@ is
 
          exit when Last_Interaction_Time + Timeout > Now;
 
-         Buttons := Update;
-         Dist := Sonar_Distance;
+         Buttons  := Update;
          Last_Cmd := Cmd;
+
+         Dist                      := Sonar_Distance;
 
          if (for some B of Buttons => B) then
             Last_Interaction_Time := Clock;
          end if;
 
-         if Dist < 20 then
+         if Dist < Rover.Safety_Distance then
             --  Ignore forward commands when close to an obstacle
             Buttons (Up) := False;
          end if;
@@ -123,6 +125,8 @@ is
          end if;
 
          Delay_Milliseconds (30);
+
+         pragma Loop_Invariant (Rover.Cannot_Crash);
       end loop;
    end Run;
 

--- a/src/rover-remote_controlled.ads
+++ b/src/rover-remote_controlled.ads
@@ -5,6 +5,10 @@ with SPARK_Mode
 is
 
    procedure Run
-     with Pre => Rover_HAL.Initialized;
+     with
+      Pre  => Rover_HAL.Initialized and then
+              Rover.Cannot_Crash,
+      Post => Rover_HAL.Initialized and then
+              Rover.Cannot_Crash;
 
 end Rover.Remote_Controlled;

--- a/src/rover-tasks.adb
+++ b/src/rover-tasks.adb
@@ -1,4 +1,3 @@
-with Rover_HAL;
 with Rover.Autonomous;
 with Rover.Remote_Controlled;
 
@@ -20,6 +19,8 @@ is
       loop
          Rover.Autonomous.Run;
          Rover.Remote_Controlled.Run;
+
+         pragma Loop_Invariant (Rover.Cannot_Crash);
       end loop;
    end Demo;
 

--- a/src/rover-tasks.ads
+++ b/src/rover-tasks.ads
@@ -5,7 +5,10 @@ with SPARK_Mode
 is
 
    procedure Demo
-     with Pre => Rover_HAL.Initialized;
+     with
+      Pre  => Rover_HAL.Initialized,
+      Post => Rover_HAL.Initialized and then
+              Rover.Cannot_Crash;
 
    pragma Export (C, Demo, "mars_rover_demo_task");
 

--- a/src/rover.ads
+++ b/src/rover.ads
@@ -1,2 +1,29 @@
-package Rover is
+with Interfaces;
+with Rover_HAL;
+package Rover with SPARK_Mode is
+
+   Safety_Distance : constant Interfaces.Unsigned_32 := 20;
+
+   function Cannot_Crash return Boolean
+     with
+       Pre    => Rover_HAL.Initialized,
+       Global => (Rover_HAL.HW_Init,
+                  Rover_HAL.Power_State,
+                  Rover_HAL.Turn_State),
+       Ghost;
+   --  Safety Requirement: The Mars Rover shall not proceed straight forward
+   --  when the distance to an obstacle is less than the Safety Distance.
+
+private
+   use type Interfaces.Unsigned_32;
+   use type Rover_HAL.Turn_Kind;
+   use type Rover_HAL.Motor_Power;
+
+   function Cannot_Crash return Boolean is
+     (if Rover_HAL.Get_Sonar_Distance < Safety_Distance and then
+         Rover_HAL.Get_Turn = Rover_HAL.Straight
+      then
+         Rover_HAL.Get_Power (Rover_HAL.Left)  <= 0 and then
+         Rover_HAL.Get_Power (Rover_HAL.Right) <= 0);
+
 end Rover;


### PR DESCRIPTION
This commit introduces a formalization of the safety requirement:

> The Mars Rover shall not proceed straight forward when the distance to
> an obstacle is less than the Safety Threshold.

via a new predicate named `Cannot_Crash`:

```ada
   function Cannot_Crash return Boolean is
     (if Rover_HAL.Get_Sonar_Distance < Safety_Distance and then
         Rover_HAL.Get_Turn = Rover_HAL.Straight
      then
         Rover_HAL.Get_Power (Rover_HAL.Left)  <= 0 and then
         Rover_HAL.Get_Power (Rover_HAL.Right) <= 0);
```

This predicate is checked in all top-level subprogram postconditions and in all relevant loops within the autonomous and remote-controlled controllers. By provind these properties, we show that at no time do the controllers for the rover command unsafe behavior.

The predicate, which is Ghost, relies on Ghost functions introduced into the Rover_HAL that model retrieving the last-command sent to turn or set motor power and the last distance obtained from the sonar. In this way, we are able to reason about what the controllers are doing without modifying the HAL implementation in any way or introducing explicit global Ghost state.

All checks prove at level 1 with GNATprove 25.1 (not FSF - FSF fails to prove the loop invariant in the remote control at level 2, even).