### PR TITLE
Fix the proof in Remote Control

### DIFF
--- a/src/rover.ads
+++ b/src/rover.ads
@@ -9,7 +9,8 @@ package Rover with SPARK_Mode is
        Pre    => Rover_HAL.Initialized,
        Global => (Rover_HAL.HW_Init,
                   Rover_HAL.Power_State,
-                  Rover_HAL.Turn_State),
+                  Rover_HAL.Turn_State,
+                  Rover_HAL.Distance_State),
        Ghost;
    --  Safety Requirement: The Mars Rover shall not proceed straight forward
    --  when the distance to an obstacle is less than the Safety Distance.

--- a/src/rover_hal.ads
+++ b/src/rover_hal.ads
@@ -4,9 +4,10 @@ package Rover_HAL
 with
   Abstract_State => (HW_Init,
                      (HW_State with Synchronous),
-                     Power_State,
-                     Turn_State),
-  Initializes    => (HW_State, Power_State, Turn_State),
+                     (Power_State with Ghost),
+                     (Turn_State with Ghost),
+                     (Distance_State with Ghost)),
+  Initializes    => (HW_State, Power_State, Turn_State, Distance_State),
   SPARK_Mode,
   Always_Terminates
 is
@@ -56,14 +57,15 @@ is
      with
        Pre    => Initialized,
        Post   => Get_Sonar_Distance = Sonar_Distance'Result,
-       Global => (HW_State, HW_Init),
+       Global => (Input => (HW_State, HW_Init),
+                  In_Out => Distance_State),
        Side_Effects,
        Volatile_Function;
 
    function Get_Sonar_Distance return Unsigned_32
      with
       Pre    => Initialized,
-      GLobal => (HW_Init),
+      Global => (HW_Init, Distance_State),
       Ghost,
       Import;
    --  Return the value of the last Sonar Distance obtained by calling


### PR DESCRIPTION
The model for `Get_Sonar_Distance` was incomplete - it did not include necessary abstract state (as was added to `Get_Turn` and `Get_Power`). As a result, the model was overconstrained and we were able to prove the safety property when we should not have been able to do so.

This commit fixes the issue and introduces a fix to the remote control code that in fact makes it safer than it was before.