### PR TITLE
Improve sensor mast control

### DIFF
--- a/src/binding/rover_hal.adb
+++ b/src/binding/rover_hal.adb
@@ -70,10 +70,10 @@ is
    ----------
 
    procedure Set_Mast_Angle (V : Mast_Angle) is
-      procedure Set_Mast_Angle_Inport (V : Integer_8);
-      pragma Import (C, Set_Mast_Angle_Inport, "mars_rover_set_mast_angle");
+      procedure Set_Mast_Angle_Import (V : Integer_8);
+      pragma Import (C, Set_Mast_Angle_Import, "mars_rover_set_mast_angle");
    begin
-      Set_Mast_Angle_Inport (Integer_8 (V));
+      Set_Mast_Angle_Import (Integer_8 (V));
    end Set_Mast_Angle;
 
    ------------
@@ -81,8 +81,17 @@ is
    ------------
 
    function Update return Buttons_State is
+      function Controller_State_Import return Unsigned_16;
+      pragma Import (C, Controller_State_Import,
+                     "mars_rover_controller_state");
+
+      Raw : constant Unsigned_16 := Controller_State_Import;
+      Result : Buttons_State;
    begin
-      return [others => False];
+      for B in Buttons loop
+         Result (B) := (Raw and Unsigned_16 (2**Buttons'Pos (B))) /= 0;
+      end loop;
+      return Result;
    end Update;
 
    ------------

--- a/src/device/rover_hal-sonar.adb
+++ b/src/device/rover_hal-sonar.adb
@@ -16,6 +16,8 @@ package body Rover_HAL.Sonar is
       IE : Atomic.Critical_Section.Interrupt_State;
       T1, T2, T3, Tick : Time;
    begin
+      Atomic.Critical_Section.Enter (IE);
+
       Configure (Pin, Output, Floating);
       Set (Pin);
       Rover_HAL.Delay_Microseconds (10);
@@ -23,9 +25,7 @@ package body Rover_HAL.Sonar is
 
       Configure (Pin, Input, Floating);
 
-      Atomic.Critical_Section.Enter (IE);
-
-      T1 := Rover_HAL.Clock;
+      T1 := Clock;
 
       while not Set (Pin) loop
          Tick := Clock;
@@ -45,7 +45,11 @@ package body Rover_HAL.Sonar is
 
       Atomic.Critical_Section.Leave (IE);
 
-      return Natural (T3 - T2);
+      if T3 <= T2 then
+         return 0;
+      else
+         return Natural (T3 - T2);
+      end if;
    end One_Shot;
 
    --------------

--- a/src/rover-mast_control.adb
+++ b/src/rover-mast_control.adb
@@ -1,0 +1,45 @@
+package body Rover.Mast_Control with SPARK_Mode is
+
+   -------------------
+   -- Next_Mast_Pos --
+   -------------------
+
+   procedure Next_Mast_Angle (This     : in out Mast_State;
+                              Min, Max : Mast_Angle;
+                              Step     : Mast_Motion_Step)
+   is
+   begin
+      if This.Angle < Min then
+         This.Angle := Min;
+      elsif This.Angle > Max then
+         This.Angle := Max;
+      end if;
+
+      case This.Direction is
+         when None =>
+            null;
+         when Left =>
+            if This.Angle <= Min + Step then
+               This.Direction := Right;
+            else
+               This.Angle := This.Angle - Step;
+            end if;
+         when Right =>
+            if This.Angle >= Max - Step then
+               This.Direction := Left;
+            else
+               This.Angle := This.Angle + Step;
+            end if;
+      end case;
+
+      Set_Mast_Angle (This.Angle);
+   end Next_Mast_Angle;
+
+   --------------
+   -- Last_Pos --
+   --------------
+
+   function Last_Angle (This : Mast_State) return Mast_Angle
+   is (This.Angle);
+
+end Rover.Mast_Control;

--- a/src/rover-mast_control.ads
+++ b/src/rover-mast_control.ads
@@ -1,0 +1,36 @@
+with Rover_HAL; use Rover_HAL;
+
+package Rover.Mast_Control with SPARK_Mode is
+
+   type Mast_State is private;
+
+   subtype Mast_Motion_Step is Mast_Angle range 1 .. 50;
+
+   procedure Next_Mast_Angle (This     : in out Mast_State;
+                              Min, Max : Mast_Angle;
+                              Step     : Mast_Motion_Step)
+     with Pre => Initialized
+               and then
+                 Min < Mast_Angle'Last - Step
+               and then
+                 Max > Mast_Angle'First - Step
+               and then
+                 Min < Max,
+         Post => Initialized
+               and then
+                 Last_Angle (This) in Min .. Max,
+         Global => (Rover_HAL.HW_State,
+                    Rover_HAL.HW_Init);
+
+   function Last_Angle (This : Mast_State) return Mast_Angle;
+
+private
+
+   type Mast_Direction is (Left, None, Right);
+
+   type Mast_State is record
+      Angle     : Mast_Angle := 0;
+      Direction : Mast_Direction := Left;
+   end record;
+
+end Rover.Mast_Control;

--- a/src/rover-remote_controlled.adb
+++ b/src/rover-remote_controlled.adb
@@ -129,13 +129,13 @@ is
                Set_Power (Left, 100);
                Set_Power (Right, 50);
             when Back_Left =>
-               Set_Turn (Right);
-               Set_Power (Left, -100);
-               Set_Power (Right, -50);
-            when Back_Right =>
                Set_Turn (Left);
                Set_Power (Left, -50);
                Set_Power (Right, -100);
+            when Back_Right =>
+               Set_Turn (Right);
+               Set_Power (Left, -100);
+               Set_Power (Right, -50);
             when others =>
                Set_Power (Left, 0);
                Set_Power (Right, 0);

--- a/src/rover_hal.ads
+++ b/src/rover_hal.ads
@@ -75,7 +75,7 @@ is
    -- Mast --
    ----------
 
-   type Mast_Angle is new  Interfaces.Integer_8 range -55 .. 55;
+   type Mast_Angle is new  Interfaces.Integer_8 range -70 .. 70;
 
    procedure Set_Mast_Angle (V : Mast_Angle)
      with


### PR DESCRIPTION
The sonar sensor reading greatly depends on the angle between the sensor
and the obstacle surface. A shallow angle reduces the ability to detect
an obstacle. It seems like the material of the obstacle also has an
impact on this.

To circumvent this limitation, we increase the rotation range and speed
of the sensor mast.

In remote mode, we stop the mast rotation when an obstacle is detected.
This way the sensor will remain focused on the detected obstacle.